### PR TITLE
Update Get-HuduAssets.ps1

### DIFF
--- a/Public/Get-HuduAssets.ps1
+++ b/Public/Get-HuduAssets.ps1
@@ -9,7 +9,7 @@ function Get-HuduAssets {
 	)
 	
 	if ($id -and $companyid) {
-		$Asset = Invoke-HuduRequest -Method get -Resource "api/v1/companies/$companyid/assets/$id"
+		$Asset = Invoke-HuduRequest -Method get -Resource "/api/v1/companies/$companyid/assets/$id"
 		return $Asset
 	} else {
 


### PR DESCRIPTION
Corrected a missed "/" on line 12 preventing the call of an asset by combined ID and Company_ID from succeeding.