### PR TITLE
Fix getting single entity for some endpoints

### DIFF
--- a/Public/Get-HuduArticles.ps1
+++ b/Public/Get-HuduArticles.ps1
@@ -9,7 +9,7 @@ function Get-HuduArticles {
 	
 	if ($Id) {
 		$Article = Invoke-HuduRequest -Method get -Resource "/api/v1/articles/$Id"
-		return $Article
+		return $Article.article
 	} else {
 
 		$ResourceFilter = ''

--- a/Public/Get-HuduAssets.ps1
+++ b/Public/Get-HuduAssets.ps1
@@ -15,7 +15,7 @@ function Get-HuduAssets {
 
 	if ($id -and $CompanyId) {
 		$Asset = Invoke-HuduRequest -Method get -Resource "/api/v1/companies/$CompanyId/assets/$Id"
-		return $Asset
+		return $Asset.asset
 	} else {
 
 		$ResourceFilter = ''

--- a/Public/Get-HuduCompanies.ps1
+++ b/Public/Get-HuduCompanies.ps1
@@ -16,7 +16,7 @@ function Get-HuduCompanies {
 
 	if ($Id) {
 		$Company = Invoke-HuduRequest -Method get -Resource "/api/v1/companies/$Id"
-		return $Company
+		return $Company.company
 	} else {
 	
 		$ResourceFilter = ''

--- a/Public/Get-HuduPasswords.ps1
+++ b/Public/Get-HuduPasswords.ps1
@@ -10,7 +10,7 @@ function Get-HuduPasswords {
 	
 	if ($Id) {
 		$Password = Invoke-HuduRequest -Method get -Resource "/api/v1/asset_passwords/$id"
-		return $Password
+		return $Password.asset_password
 	} else {
 
 		$ResourceFilter = ''

--- a/Public/Get-HuduProcesses.ps1
+++ b/Public/Get-HuduProcesses.ps1
@@ -10,7 +10,7 @@ function Get-HuduProcesses {
 	
 	if ($Id) {
 		$Process = Invoke-HuduRequest -Method get -Resource "/api/v1/procedures/$id"
-		return $Process
+		return $Process.procedure
 	} else {
 
 		$ResourceFilter = ''


### PR DESCRIPTION
Tweaked following commands so they return the nested object when getting a single item:
`Get-HuduArticles `
`Get-HuduAssets`
`Get-HuduCompanies `
`Get-HuduPasswords `
`Get-HuduProcesses `

This makes getting a single item behave the same as getting multiple items.