### PR TITLE
Change Name param to a String instead of Int in Get-HuduFolders

### DIFF
--- a/Public/Get-HuduFolders.ps1
+++ b/Public/Get-HuduFolders.ps1
@@ -2,7 +2,7 @@ function Get-HuduFolders {
 	[CmdletBinding()]
 	Param (
 		[Int]$Id = '',
-		[Int]$Name = '',
+		[String]$Name = '',
 		[Alias("company_id")]
 		[Int]$CompanyId = ''
 	)


### PR DESCRIPTION
Bug fix: Get-PublicFolders Name param was erroring when I was trying to use it to filter on the folder name because it only accepts an Integer. Changed this to a String, and confirmed this works for me now.