### PR TITLE
Validation patch for asset field types

### DIFF
--- a/HuduAPI/Public/New-HuduAssetLayout.ps1
+++ b/HuduAPI/Public/New-HuduAssetLayout.ps1
@@ -37,11 +37,17 @@ function New-HuduAssetLayout {
     Url identifier
 
     .PARAMETER Fields
-    Array of nested fields
+    Array of hashtable or custom objects representing layout fields. Most field types only require a label and type.
+    Valid field types are: Text, RichText, Heading, CheckBox, Website (aka Link), Password (aka ConfidentialText), Number, Date, DropDown, Embed, Email (aka CopyableText), Phone, AssetLink
+    Field types are Case Sensitive as of Hudu V2.27 due to a known issue with asset type validation.
 
     .EXAMPLE
     New-HuduAssetLayout -Name 'Test asset layout' -Icon 'fas fa-home' -IncludePassword $true
 
+    .EXAMPLE
+    New-HuduAssetLayout -Name 'Test asset layout' -Icon 'fas fa-home' -IncludePassword $true -Fields @(
+        @{label = 'Test field'; 'field_type' = 'Text'}
+    )
     #>
     [CmdletBinding(SupportsShouldProcess)]
     # This will silence the warning for variables with Password in their name.
@@ -83,6 +89,23 @@ function New-HuduAssetLayout {
         if ($field.show_in_list) { $field.show_in_list = [System.Convert]::ToBoolean($field.show_in_list) } else { $field.remove('show_in_list') }
         if ($field.required) { $field.required = [System.Convert]::ToBoolean($field.required) } else { $field.remove('required') }
         if ($field.expiration) { $field.expiration = [System.Convert]::ToBoolean($field.expiration) } else { $field.remove('expiration') }
+        # A bug in versions of Hudu 2.27 and earlier can cause asset layouts to become corrupted if the field type value is not properly cased.
+        switch ($field.'field_type') {
+            'text'              { $field.'field_type' = 'Text' }
+            'richtext'          { $field.'field_type' = 'RichText' }
+            'heading'           { $field.'field_type' = 'Heading' }
+            'checkbox'          { $field.'field_type' = 'CheckBox' }
+            'number'            { $field.'field_type' = 'Number' }
+            'date'              { $field.'field_type' = 'Date' }
+            'dropdown'          { $field.'field_type' = 'Dropdown' }
+            'embed'             { $field.'field_type' = 'Embed' }
+            'phone'             { $field.'field_type' = 'Phone' }
+            ('email'    -or 'copyabletext')     { $field.'field_type' = 'Email' }
+            ('assettag' -or 'assetlink')        { $field.'field_type' = 'AssetTag' }
+            ('website'  -or 'link')             { $field.'field_type' = 'Website' }
+            ('password' -or 'confidentialtext') { $field.'field_type' = 'Password' }
+            Default { Write-Error "Invalid field type: $($field.'field_type') found in field $($field.name)"; break }
+        }
     }
 
     $AssetLayout = [ordered]@{asset_layout = [ordered]@{} }

--- a/HuduAPI/Public/Set-HuduAssetLayout.ps1
+++ b/HuduAPI/Public/Set-HuduAssetLayout.ps1
@@ -40,11 +40,17 @@ function Set-HuduAssetLayout {
     Url identifier
 
     .PARAMETER Fields
-    Array of nested fields
+    Array of hashtable or custom objects representing layout fields. Most field types only require a label and type.
+    Valid field types are: Text, RichText, Heading, CheckBox, Website (aka Link), Password (aka ConfidentialText), Number, Date, DropDown, Embed, Email (aka CopyableText), Phone, AssetLink
+    Field types are Case Sensitive as of Hudu V2.27 due to a known issue with asset type validation.
 
     .EXAMPLE
+    Set-HuduAssetLayout -Id 12 -Name 'Test asset layout' -Icon 'fas fa-home' -IncludePassword $true
 
-
+    .EXAMPLE
+    Set-HuduAssetLayout -Id 12 -Fields @(
+        @{label = 'Test field'; 'field_type' = 'Text'}
+    )
     #>
     [CmdletBinding(SupportsShouldProcess)]
     # This will silence the warning for variables with Password in their name.
@@ -88,6 +94,23 @@ function Set-HuduAssetLayout {
         $Field.show_in_list = [System.Convert]::ToBoolean($Field.show_in_list)
         $Field.required = [System.Convert]::ToBoolean($Field.required)
         $Field.expiration = [System.Convert]::ToBoolean($Field.expiration)
+        # A bug in versions of Hudu 2.27 and earlier can cause asset layouts to become corrupted if the field type value is not properly cased.
+        switch ($field.'field_type') {
+            'text'              { $field.'field_type' = 'Text' }
+            'richtext'          { $field.'field_type' = 'RichText' }
+            'heading'           { $field.'field_type' = 'Heading' }
+            'checkbox'          { $field.'field_type' = 'CheckBox' }
+            'number'            { $field.'field_type' = 'Number' }
+            'date'              { $field.'field_type' = 'Date' }
+            'dropdown'          { $field.'field_type' = 'Dropdown' }
+            'embed'             { $field.'field_type' = 'Embed' }
+            'phone'             { $field.'field_type' = 'Phone' }
+            ('email'    -or 'copyabletext')     { $field.'field_type' = 'Email' }
+            ('assettag' -or 'assetlink')        { $field.'field_type' = 'AssetTag' }
+            ('website'  -or 'link')             { $field.'field_type' = 'Website' }
+            ('password' -or 'confidentialtext') { $field.'field_type' = 'Password' }
+            Default { Write-Error "Invalid field type: $($field.'field_type') found in field $($field.name)"; break }
+        }
     }
     $Object = Get-HuduAssetLayouts -id $Id
 


### PR DESCRIPTION
resolves #48 

Validate and hard-set casing on field_type values to protect against a known issue in the Hudu API. In current versions of Hudu, the field_type value is case-sensitive and not validated server-side.  Sending a field_type value that is improperly cased can corrupt the asset, requiring manual removal from the database or restoring Hudu from a backup.

Relevent discussion in the MSPGeek Hudu Discord - https://discord.com/channels/801971115013963818/921032269546782720/1184556878689222716