### PR TITLE
Fixed issue with CompanyType in New-HuduCompany

### DIFF
--- a/HuduAPI/Public/New-HuduCompany.ps1
+++ b/HuduAPI/Public/New-HuduCompany.ps1
@@ -108,7 +108,7 @@ function New-HuduCompany {
 
     $Company.company.add('name', $Name)
     if (-not ([string]::IsNullOrEmpty($Nickname))) { $Company.company.add('nickname', $Nickname) }
-    if (-not ([string]::IsNullOrEmpty($Nickname))) { $Company.company.add('company_type', $CompanyType) }
+    if (-not ([string]::IsNullOrEmpty($CompanyType))) { $Company.company.add('company_type', $CompanyType) }
     if (-not ([string]::IsNullOrEmpty($AddressLine1))) { $Company.company.add('address_line_1', $AddressLine1) }
     if (-not ([string]::IsNullOrEmpty($AddressLine2))) { $Company.company.add('address_line_2', $AddressLine2) }
     if (-not ([string]::IsNullOrEmpty($City))) { $Company.company.add('city', $City) }


### PR DESCRIPTION
In `New-HuduCompany`, line 111 was incorrectly checking if `$Nickname` was null or empty for the CompanyType field.

```powershell
if (-not ([string]::IsNullOrEmpty($Nickname))) { $Company.company.add('company_type', $CompanyType) }
```

I've changed that line to correctly check CompanyType

```powershell
if (-not ([string]::IsNullOrEmpty($CompanyType))) { $Company.company.add('company_type', $CompanyType) }
```