### PR TITLE
error objects

### DIFF
--- a/HuduAPI/Private/Invoke-HuduRequest.ps1
+++ b/HuduAPI/Private/Invoke-HuduRequest.ps1
@@ -9,9 +9,6 @@ function Invoke-HuduRequest {
     .PARAMETER Method
     GET,POST,DELETE,PUT,etc
 
-    .PARAMETER Path
-    Path to API endpoint
-
     .PARAMETER Params
     Hashtable of parameters
 
@@ -111,6 +108,7 @@ function Invoke-HuduRequest {
             Write-Host "Hudu API Rate limited; Sleeping for $totalSleep seconds to wait for next rate limit window..."
             Start-Sleep -Seconds $totalSleep
         } else {
+            if ($global:SKIP_HAPI_ERROR_RETRY -and $true -eq $global:SKIP_HAPI_ERROR_RETRY) { return $null }
             Write-APIErrorObject -name "$path-$method" -ErrorObject @{
                 exception = $_
                 request = $RestMethod

--- a/HuduAPI/Private/Write-ErrorObject.ps1
+++ b/HuduAPI/Private/Write-ErrorObject.ps1
@@ -4,9 +4,17 @@ function Write-APIErrorObject {
         [object]$ErrorObject,
 
         [Parameter()]
-        [string]$Name = "Unnamed"
-    )
+        [string]$Name = "unnamed",
 
+        [Parameter()]
+        [ValidateSet("Black","DarkBlue","DarkGreen","DarkCyan","DarkRed","DarkMagenta","DarkYellow","Gray","DarkGray","Blue","Green","Cyan","Red","Magenta","Yellow","White")]
+        [string]$Color
+
+    )
+    <#
+    .SYNOPSIS
+    Unwraps and prints an object, error, and logs error to a specific file safely.
+#>
     $stringOutput = try {
         $ErrorObject | Format-List -Force | Out-String
     } catch {
@@ -36,11 +44,25 @@ $propertyDump
 "@
 
     if ($global:HAPI_ERRORS_DIRECTORY -and (Test-Path $global:HAPI_ERRORS_DIRECTORY)) {
-        $filename = "$($Name.Trim())_error_$(Get-Date -Format 'yyyyMMdd_HHmmss').log"
-        $fullPath = Join-Path $global:HAPI_ERRORS_DIRECTORY $filename
+        $SafeName = ($Name -replace '[\\/:*?"<>|]', '_') -replace '\s+', ''
+        if ($SafeName.Length -gt 60) {
+            $SafeName = $SafeName.Substring(0, 60)
+        }
+        $filename = "${SafeName}_error_$(Get-Date -Format 'yyyyMMdd_HHmmss').log"
+        $fullPath = Join-Path $ErroredItemsFolder $filename
         Set-Content -Path $fullPath -Value $logContent -Encoding UTF8
-        Write-Host "Error written to $fullPath" -ForegroundColor Yellow
+        if ($Color) {
+            Write-Host "Error written to $fullPath" -ForegroundColor $Color
+        } else {
+            Write-Host "Error written to $fullPath"
+        }
     }
 
-    Write-Host "$logContent" -ForegroundColor Yellow
+    if ($global:HAPI_ERROR_COLOR -and @("Black","DarkBlue","DarkGreen","DarkCyan","DarkRed","DarkMagenta","DarkYellow","Gray","DarkGray","Blue","Green","Cyan","Red","Magenta","Yellow","White") -contains $global:HAPI_ERROR_COLOR) {
+        Write-Host "$logContent" -ForegroundColor $global:HAPI_ERROR_COLOR
+    } elseif ($Color) {
+        Write-Host "$logContent" -ForegroundColor $Color
+    } else {
+        Write-Host "$logContent"
+    }
 }


### PR DESCRIPTION
prints error object of your specification and writes it to file if error directory exists.

HAPI_ERRORS_DIRECTORY=
if you dont specify a path (which exists), it will simply print out the request, payload, anything else that you include in -errorobject param, which can take just about any input object

HAPI_ERROR_COLOR=
set error color to something festive and bright, otherwise doesnt print with color

SKIP_HAPI_ERROR_RETRY=
this will skip retry and not print or write errors when set to $true. defaults to null / false. good if you are about to run a section that may include errors that we dont need to track